### PR TITLE
[wip] Add Ruby 2.5 and ruby-switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+*.swp

--- a/provision.sh
+++ b/provision.sh
@@ -72,8 +72,9 @@ echo "[PROVISIONER] Installing ruby"
 sudo apt-get -y install software-properties-common
 sudo apt-add-repository ppa:brightbox/ruby-ng
 sudo apt-get update
+sudo apt-get -y install ruby2.5 ruby2.5-dev
 sudo apt-get -y install ruby2.3 ruby2.3-dev
-sudo gem install bundler
+sudo apt-get -y install ruby-switch
 
 echo "[PROVISIONER] Installing awscli"
 pip install awscli --upgrade --user


### PR DESCRIPTION
This PR installs Ruby 2.5 as default Ruby version and adds [`ruby-switch`](https://www.brightbox.com/docs/ruby/ubuntu/#switching-the-default-ruby-version) for managing Ruby versions.

Also, since running `bundle install` after switching the Ruby version raises an incompatibility message, I've removed `sudo gem install bundler`. I'll take a closer look into this.

For the time being, above mentioned issue can be addressed by installing Bundler with sudo for both Ruby versions.